### PR TITLE
fix: remove rpcProvider to render shader

### DIFF
--- a/src/components/ShaderComponent.js
+++ b/src/components/ShaderComponent.js
@@ -11,13 +11,8 @@ export const ShaderComponent = () => {
     React.useEffect(() => {
       const canvas = canvasRef
       var sandbox = new GlslCanvas(canvas.current)
-      const rpcProvider = new ethers.providers.JsonRpcProvider(process.env.RPC_ENDPOINT)
-
-      rpcProvider.getBlockNumber().then((num) => {
-        sandbox.load(ShaderFragment)
-        sandbox.setUniform('u_seed', Math.pow(num, 0.5))
-      })
-
+      sandbox.load(ShaderFragment)
+      sandbox.setUniform('u_seed', Math.pow(14076080, 0.5))
       canvas.current.style.width = '100%'
     }, [])
     return <canvas className="shader-canvas" ref={canvasRef} />


### PR DESCRIPTION
## Summary

Rather than retrieving the block number, this hardcodes an integer to render the shader. This removes the `rpcProvider` altogether to render the site and get things going.